### PR TITLE
python-ldap v3.4.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,9 @@ source:
 
 build:
   number: 0
+  # openldap is not available on Windows
   skip: true  # [win]
-  script:
-    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
   build:
@@ -22,18 +22,17 @@ requirements:
   host:
     - python
     - setuptools
+    - setuptools-scm
     - pip
-    - wheel
-    - pyasn1 >=0.3.7
-    - pyasn1-modules >=0.1.5
     - openldap {{ openldap }}
   run:
     - python
     - pyasn1 >=0.3.7
     - pyasn1-modules >=0.1.5
-    - openldap {{ openldap }}
 
 test:
+  # Slapd builds are skipped in 'openldap' feedstock: https://github.com/AnacondaRecipes/openldap-feedstock/blob/master/recipe/build.sh
+  # Upstream tests need slapd, the rest of the tests are very basic and not testing the LDAP functionality of the package
   requires:
     - pip
   imports:
@@ -45,7 +44,7 @@ test:
     - pip check
 
 about:
-  home: https://www.python-ldap.org/
+  home: https://www.python-ldap.org
   license: PSF-2.0 and MIT
   license_family: Other
   license_file:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,18 @@
 {% set name = "python-ldap" %}
-{% set version = "3.4.0" %}
+{% set version = "3.4.5" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 60464c8fc25e71e0fd40449a24eae482dcd0fb7fcf823e7de627a6525b3e0d12
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: b2f6ef1c37fe2c6a5a85212efe71311ee21847766a7d45fcb711f3b270a5f79a
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
   script:
-    # For whatever reason upstream resigned from libldap_r dynamic lib naming, although Linux build still uses it
-    # https://lists.openldap.org/hyperkitty/list/openldap-devel@openldap.org/thread/EZVZ7VFBIUTLS4VKOLB5YX74HHNLCX4W/
-    - ln -s ${PREFIX}/lib/libldap.so ${PREFIX}/lib/libldap_r.so  # [linux]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
@@ -23,53 +20,42 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
-    - pip
-    - wheel
     - python
     - setuptools
-    # https://github.com/python-ldap/python-ldap/blob/python-ldap-3.4.0/CHANGES#L95-L97: OSX comes with preinstalled libldap
-    - openldap {{ openldap }}  # [linux]
+    - pip
+    - wheel
+    - pyasn1 >=0.3.7
+    - pyasn1-modules >=0.1.5
+    - openldap {{ openldap }}
   run:
     - python
-    - pyasn1
-    - pyasn1-modules
-
-# sldap is not available at runtime on either platform: https://github.com/python-ldap/python-ldap/blob/a73ce552db1d5250e62ea88999a5b2d480cd8153/tox.ini#L70
-{% set specific_tests = "t_cidict.py" %}
-{% set specific_tests = specific_tests + " t_ldap_dn.py" %}
-{% set specific_tests = specific_tests + " t_ldap_filter.py" %}
-{% set specific_tests = specific_tests + " t_ldap_functions.py" %}
-{% set specific_tests = specific_tests + " t_ldap_modlist.py" %}
-{% set specific_tests = specific_tests + " t_ldap_schema_tokenizer.py" %}
-{% set specific_tests = specific_tests + " t_ldapurl.py" %}
-{% set specific_tests = specific_tests + " t_ldif.py" %}
-{% set specific_tests = specific_tests + " t_untested_mods.py" %}
+    - pyasn1 >=0.3.7
+    - pyasn1-modules >=0.1.5
+    - openldap {{ openldap }}
 
 test:
-  source_files:
-    - Tests
+  requires:
+    - pip
   imports:
     - ldap
     - ldap.controls
     - ldap.extop
     - ldap.schema
-  requires:
-    - pip
-    - pytest
   commands:
     - pip check
-    - cd Tests && pytest -v {{ specific_tests }}
 
 about:
   home: https://www.python-ldap.org/
-  license: PSF-2.0
-  license_family: PSF
-  license_file: LICENCE
+  license: PSF-2.0 and MIT
+  license_family: Other
+  license_file:
+    - LICENCE
+    - LICENCE.MIT
   summary: Python modules for implementing LDAP clients
   description: |
-    python-ldap provides an object-oriented API to access LDAP directory servers 
+    python-ldap provides an object-oriented API to access LDAP directory servers
     from Python programs. Mainly it wraps the OpenLDAP client libs for that purpose.
-  doc_url: https://www.python-ldap.org/en/latest/
+  doc_url: https://www.python-ldap.org
   dev_url: https://github.com/python-ldap/python-ldap
 
 extra:


### PR DESCRIPTION
python-ldap 3.4.5

**Destination channel:** defaults

### Links

- [PKG-11644](https://anaconda.atlassian.net/browse/PKG-11644) 
- [Upstream repository](https://github.com/python-ldap/python-ldap)
- [Upstream changelog/diff](https://github.com/python-ldap/python-ldap/releases/tag/python-ldap-3.4.5)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Version bump to 3.4.5
- Enable Python 3.14 builds
- Remove upstream tests due to missing package, `slapd`. Ignoring the tests involving `slapd` seems to ignore all the LDAP functionality tests
  - Upstream tests require `unittest`, not `pytest`
  - For some reason, `pytest` won't discover the `unittest` tests
- Clean up the recipe a bit


[PKG-11644]: https://anaconda.atlassian.net/browse/PKG-11644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ